### PR TITLE
Add python scripts for model prediction.

### DIFF
--- a/src/data/retrieval_dataloader.py
+++ b/src/data/retrieval_dataloader.py
@@ -113,7 +113,7 @@ class MmtRetrievalDataLoader(data_loader.DataLoader):
 
     drop_remainder = config.drop_remainder
 
-    if config.input_path != '':
+    if config.input_path:
       # Image-text pairs are already provided in records.
       input_patterns = config.input_path.split(',')
       data_utils.check_input_patterns(input_patterns)
@@ -202,7 +202,7 @@ class MmtRetrievalDataLoader(data_loader.DataLoader):
         num_parallel_calls=tf.data.experimental.AUTOTUNE)
 
     # Shards image pairs after enumerate all possible combinations.
-    if (input_context and input_context.num_input_pipelines > 1):
+    if input_context and input_context.num_input_pipelines > 1:
       dataset = dataset.shard(input_context.num_input_pipelines,
                               input_context.input_pipeline_id)
 

--- a/src/data/retrieval_dataloader.py
+++ b/src/data/retrieval_dataloader.py
@@ -1,0 +1,260 @@
+# Copyright 2021 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loads dataset for the Mmt prediction."""
+
+import dataclasses
+import json
+from typing import Optional
+
+import tensorflow as tf
+import tensorflow_text as tf_text
+from official.nlp.data import data_loader
+from official.nlp.data import data_loader_factory
+
+from data import data_utils
+from data import configs
+
+
+@dataclasses.dataclass
+class MmtRetrievalDataConfig(configs.MmtDataConfig):
+  """Data config for Mmt retrieval task."""
+  # If we store image and text records seperately, we provide image and text
+  # record paths separately and enumerate all possible combinations on the fly.
+  image_input_path: str = ''
+  text_input_path: str = ''
+  num_image_examples: int = 0
+  num_text_examples: int = 0
+
+  negative_positive_ratio: int = 1
+  pos_weight: float = 1.0
+  drop_remainder: bool = False
+  include_image_text_index: bool = True
+
+
+@data_loader_factory.register_data_loader_cls(MmtRetrievalDataConfig)
+class MmtRetrievalDataLoader(data_loader.DataLoader):
+  """A class to load dataset for mmt retrieval task."""
+
+  def __init__(self, params):
+    """Inits `MmtRetrievalDataLoader` class.
+
+    Args:
+      params: A `MmtDataConfig` object.
+
+    """
+    self._params = params
+    self._image_data_field = params.image_data_field
+    self._text_special_token_field_dict = json.loads(params.text_special_token_field_dict)
+    self._is_prebuilt_pairs = params.input_path != ''
+    self.image_name_to_features = self._image_name_to_features()
+    self.text_name_to_features = self._text_name_to_features()
+
+  def _image_name_to_features(self):
+    # TODO(roylu): Unify the name of index during preprocessing.
+    if self._is_prebuilt_pairs:
+      index_key = 'image_index'
+    else:
+      index_key = 'index'
+
+    name_to_features = {
+        index_key: tf.io.FixedLenFeature([], tf.int64),
+        self._image_data_field: tf.io.FixedLenFeature([], tf.string)
+    }
+    return name_to_features
+
+  def _text_name_to_features(self):
+    # TODO(roylu): Unify the name of index during preprocessing.
+    if self._is_prebuilt_pairs:
+      index_key = 'text_index'
+    else:
+      index_key = 'index'
+
+    name_to_features = {
+        index_key: tf.io.FixedLenFeature([], tf.int64),
+        'gt_image_index': tf.io.FixedLenFeature([], tf.int64),
+    }
+    for k in self._text_special_token_field_dict.keys():
+      name_to_features[k] = tf.io.FixedLenFeature([], tf.string,
+                                                  default_value='')
+    return name_to_features
+
+  def load(self,
+           input_context: Optional[tf.distribute.InputContext] = None):
+    """Returns a tf.dataset.Dataset."""
+
+    input_keys = ['word_ids',
+                  'segment_ids',
+                  'patch_embeddings',
+                  'att_mask',
+                  'relative_att_ids']
+
+    label_keys = ['label_ids',
+                  'label_weights']
+
+    keep_feature_keys = []
+    keep_feature_keys.extend(label_keys)
+    keep_feature_keys.extend(input_keys)
+
+    config = self._params
+
+    tokenizer = tf_text.BertTokenizer(config.vocab_filename,
+                                      lower_case=True,
+                                      preserve_unused_token=True,
+                                      token_out_type=tf.int32)
+
+    # This dataloader is currently for prediction only. However, it could be
+    # modified for training.
+    is_training = config.is_training
+    if config.include_image_text_index:
+      index_keys = ['image_index', 'text_index', 'gt_image_index']
+      input_keys.extend(index_keys)
+      keep_feature_keys.extend(index_keys)
+
+    batch_size_per_replica = input_context.get_per_replica_batch_size(
+        config.global_batch_size)
+
+    drop_remainder = config.drop_remainder
+
+    if config.input_path != '':
+      # Image-text pairs are already provided in records.
+      input_patterns = config.input_path.split(',')
+      data_utils.check_input_patterns(input_patterns)
+      dataset = tf.data.Dataset.list_files(input_patterns,
+                                           shuffle=is_training,
+                                           seed=config.seed)
+
+      dataset = dataset.interleave(
+          tf.data.TFRecordDataset,
+          cycle_length=config.cycle_length,
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+      name_to_features = {**self.image_name_to_features,
+                          **self.text_name_to_features}
+      decode_fn = data_utils.get_decode_fn(name_to_features,
+                                           tokenizer,
+                                           config,
+                                           merge_dims=True,
+                                           is_training=is_training)
+      dataset = dataset.map(
+          decode_fn,
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+    else:
+      # Creates image-text pairs from image and text records.
+      image_input_patterns = config.image_input_path.split(',')
+      text_input_patterns = config.text_input_path.split(',')
+      data_utils.check_input_patterns(image_input_patterns)
+      data_utils.check_input_patterns(text_input_patterns)
+
+      # No need to shuffle files here because we will enumerate all combinations.
+      image_dataset = tf.data.Dataset.list_files(image_input_patterns,
+                                                 shuffle=is_training,
+                                                 seed=config.seed)
+      text_dataset = tf.data.Dataset.list_files(text_input_patterns,
+                                                shuffle=is_training,
+                                                seed=config.seed)
+
+      image_dataset = image_dataset.interleave(
+          tf.data.TFRecordDataset,
+          cycle_length=config.cycle_length,
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+      text_dataset = text_dataset.interleave(
+          tf.data.TFRecordDataset,
+          cycle_length=config.cycle_length,
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+      # Gets mapping functions.
+      image_decode_fn = data_utils.get_decode_fn(self.image_name_to_features,
+                                                 tokenizer,
+                                                 config,
+                                                 merge_dims=True,
+                                                 is_training=is_training,
+                                                 decode_image=True,
+                                                 decode_text=False)
+
+      text_decode_fn = data_utils.get_decode_fn(self.text_name_to_features,
+                                                tokenizer,
+                                                config,
+                                                merge_dims=True,
+                                                is_training=is_training,
+                                                decode_image=False,
+                                                decode_text=True)
+
+      image_dataset = image_dataset.map(
+          image_decode_fn,
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+      text_dataset = text_dataset.map(
+          text_decode_fn,
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+      # Enumerates all possible combinations of image-text pairs.
+      # For example, image = [a, b, c]; text = [x, y].
+      # All combinations = [(a, x), (a, y), (b, x), (b, y), (c, x), (c, y)].
+      dataset = text_dataset.interleave(
+          lambda x: image_dataset.interleave(
+              lambda y: data_utils.combine_image_text(x, y),
+              num_parallel_calls=tf.data.experimental.AUTOTUNE),
+          num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+    # Gets the label of the image-text pair by matching image_index in
+    # image_dataset and gt_image_indx in text_dataset.
+    get_label = data_utils.get_retrieval_label_fn(self._params.pos_weight)
+    dataset = dataset.map(
+        get_label,
+        num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+    # Shards image pairs after enumerate all possible combinations.
+    if (input_context and input_context.num_input_pipelines > 1):
+      dataset = dataset.shard(input_context.num_input_pipelines,
+                              input_context.input_pipeline_id)
+
+    word_ids_fn = data_utils.get_word_ids_fn(config)
+
+    # TODO(roylu): relative_pos_max_distance and relative_att_num_core_layers 
+    # should be defined in the model config. No model config is passed into this
+    # function.
+    add_side_input_features_fn = data_utils.get_add_side_input_features_fn(
+        config,
+        config.relative_pos_max_distance,
+        config.relative_att_num_core_layers)
+    pop_fn = data_utils.get_pop_fn(keep_feature_keys)
+    split_features_fn = data_utils.get_split_features_fn(input_keys, label_keys)
+
+    if is_training:
+      dataset = dataset.repeat()
+      dataset = dataset.shuffle(4096, seed=config.seed)
+
+    dataset = dataset.map(
+        word_ids_fn,
+        num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+    dataset = dataset.map(
+        add_side_input_features_fn,
+        tf.data.experimental.AUTOTUNE)
+
+    dataset = dataset.map(
+        pop_fn,
+        num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+    dataset = dataset.map(
+        split_features_fn,
+        num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
+    dataset = dataset.batch(batch_size_per_replica,
+                            drop_remainder=drop_remainder)
+
+    dataset = dataset.prefetch(tf.data.experimental.AUTOTUNE)
+
+    return dataset

--- a/src/data/retrieval_dataloader.py
+++ b/src/data/retrieval_dataloader.py
@@ -57,32 +57,19 @@ class MmtRetrievalDataLoader(data_loader.DataLoader):
     self._params = params
     self._image_data_field = params.image_data_field
     self._text_special_token_field_dict = json.loads(params.text_special_token_field_dict)
-    self._is_prebuilt_pairs = params.input_path != ''
     self.image_name_to_features = self._image_name_to_features()
     self.text_name_to_features = self._text_name_to_features()
 
   def _image_name_to_features(self):
-    # TODO(roylu): Unify the name of index during preprocessing.
-    if self._is_prebuilt_pairs:
-      index_key = 'image_index'
-    else:
-      index_key = 'index'
-
     name_to_features = {
-        index_key: tf.io.FixedLenFeature([], tf.int64),
+        'image_index': tf.io.FixedLenFeature([], tf.int64),
         self._image_data_field: tf.io.FixedLenFeature([], tf.string)
     }
     return name_to_features
 
   def _text_name_to_features(self):
-    # TODO(roylu): Unify the name of index during preprocessing.
-    if self._is_prebuilt_pairs:
-      index_key = 'text_index'
-    else:
-      index_key = 'index'
-
     name_to_features = {
-        index_key: tf.io.FixedLenFeature([], tf.int64),
+        'text_index': tf.io.FixedLenFeature([], tf.int64),
         'gt_image_index': tf.io.FixedLenFeature([], tf.int64),
     }
     for k in self._text_special_token_field_dict.keys():
@@ -117,10 +104,9 @@ class MmtRetrievalDataLoader(data_loader.DataLoader):
     # This dataloader is currently for prediction only. However, it could be
     # modified for training.
     is_training = config.is_training
-    if config.include_image_text_index:
-      index_keys = ['image_index', 'text_index', 'gt_image_index']
-      input_keys.extend(index_keys)
-      keep_feature_keys.extend(index_keys)
+    index_keys = ['image_index', 'text_index', 'gt_image_index']
+    input_keys.extend(index_keys)
+    keep_feature_keys.extend(index_keys)
 
     batch_size_per_replica = input_context.get_per_replica_batch_size(
         config.global_batch_size)

--- a/src/predict.py
+++ b/src/predict.py
@@ -22,12 +22,10 @@ from absl import app
 from absl import flags
 from absl import logging
 
-import tensorflow as tf
-
-# Imports registered experiment configs.
 from official.core import exp_factory
 from official.core import task_factory
 from official.modeling.hyperparams import params_dict
+import tensorflow as tf
 
 import distribute_utils
 import prediction_helper

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,0 +1,152 @@
+# coding=utf-8
+# Copyright 2021 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs prediction."""
+
+import json
+import pprint
+
+from absl import app
+from absl import flags
+from absl import logging
+
+import tensorflow as tf
+
+# Imports registered experiment configs.
+from official.core import exp_factory
+from official.core import task_factory
+from official.modeling.hyperparams import params_dict
+
+import distribute_utils
+import prediction_helper
+import registry_imports
+
+
+# Device configs.
+flags.DEFINE_string(
+    'distribution_strategy',
+    default='tpu',
+    help='The Distribution Strategy to use for prediction.')
+
+flags.DEFINE_string(
+    'tpu',
+    default='',
+    help='The Cloud TPU to use for training.')
+
+flags.DEFINE_string(
+    'tpu_zone',
+    default=None,
+    help='zone of TPUs.')
+
+flags.DEFINE_integer(
+    'predict_global_batch_size',
+    default=2048,
+    help='batch size while prediction.')
+
+flags.DEFINE_string(
+    'test_output_dir',
+    default=None,
+    help='The dir to the test output data.')
+
+flags.DEFINE_string(
+    'input_meta_data_path',
+    default=None,
+    help='Path to file that contains metadata about input file.')
+
+flags.DEFINE_string(
+    'init_checkpoint',
+    default=None,
+    help='Initial checkpoint from a pre-trained BERT model.')
+
+flags.DEFINE_multi_string(
+    'config_file',
+    default=None,
+    help='File to specify the `ExperimentConfig` directly.')
+
+flags.DEFINE_string(
+    'predict_split',
+    default='val',
+    help='split that is used for prediction.')
+
+FLAGS = flags.FLAGS
+
+EXPERIMENT_TYPE = 'mmt/classification'
+
+
+def _override_exp_config_by_file(exp_config, exp_config_files):
+  """Overrides an `ExperimentConfig` object by files."""
+  for exp_config_file in exp_config_files:
+    if not tf.io.gfile.exists(exp_config_file):
+      raise ValueError('%s does not exist.' % exp_config_file)
+    params_dict.override_params_dict(
+        exp_config, exp_config_file, is_strict=True)
+
+  return exp_config
+
+
+def _get_exp_config(input_meta_data, exp_config_files):
+  """Gets an `ExperimentConfig` object."""
+  exp_config = exp_factory.get_exp_config(EXPERIMENT_TYPE)
+
+  logging.info('Loading `ExperimentConfig` from file.')
+  exp_config = _override_exp_config_by_file(exp_config, exp_config_files)
+
+  exp_config.validate()
+  exp_config.lock()
+
+  pp = pprint.PrettyPrinter()
+  logging.info('Final experiment parameters: %s',
+               pp.pformat(exp_config.as_dict()))
+
+  return exp_config
+
+
+def _check_path_exists(flag_path, flag_name):
+  if not tf.io.gfile.exists(flag_path):
+    raise ValueError('Flag `%s` at %s does not exist.' %
+                     (flag_name, flag_path))
+
+
+def _validate_path(flag_path, flag_name):
+  if not flag_path:
+    raise ValueError(f'Flag `{flag_name}` must be provided')
+  _check_path_exists(flag_path, flag_name)
+
+
+def main(argv):
+  if len(argv) > 1:
+    raise app.UsageError('Too many command-line arguments.')
+
+  _validate_path(FLAGS.input_meta_data_path, 'input_meta_data_path')
+
+  distribution_strategy = distribute_utils.get_distribution_strategy(
+      distribution_strategy=FLAGS.distribution_strategy,
+      tpu_address=FLAGS.tpu,
+      zone=FLAGS.tpu_zone)
+
+  with tf.io.gfile.GFile(FLAGS.input_meta_data_path, 'rb') as reader:
+    input_meta_data = json.loads(reader.read().decode('utf-8'))
+
+  with distribution_strategy.scope():
+    logging.info('Starting predict...')
+    exp_config_files = FLAGS.config_file
+    exp_config = _get_exp_config(input_meta_data=input_meta_data,
+                                 exp_config_files=exp_config_files)
+    task = task_factory.get_task(exp_config.task)
+    prediction_helper.write_results(task, input_meta_data, FLAGS)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/src/prediction_helper.py
+++ b/src/prediction_helper.py
@@ -27,7 +27,7 @@ from data import retrieval_dataloader
 from tasks import classification
 
 
-def get_recall_at_k_from_dataframe(df, topks=[1, 3, 5, 10]):
+def get_recall_at_k_from_dataframe(df, topks=(1, 3, 5, 10)):
   """Gets recall@k from a dataframe.
 
   The dataframe should contains 4 columns: image_index, text_index,

--- a/src/prediction_helper.py
+++ b/src/prediction_helper.py
@@ -1,0 +1,197 @@
+# coding=utf-8
+# Copyright 2021 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+"""The helper for prediction."""
+import collections
+import json
+import os
+import pprint
+
+from absl import logging
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+
+from data import retrieval_dataloader
+from tasks import classification
+
+
+def get_recall_at_k_from_dataframe(df, topks=[1, 3, 5, 10]):
+  """Gets recall@k from a dataframe.
+
+  The dataframe should contains 4 columns: image_index, text_index,
+  gt_image_index, and output.
+
+  """
+  score_matrix = df.pivot_table(values='output',
+                                index='image_index',
+                                columns='text_index').values
+  # If inference examples do not share the same pool, there will be missing
+  # values in the score_matrix. Since all scores are positive, we replace the
+  # missing values with -1 to ignore them when sorting.
+  score_matrix = np.nan_to_num(score_matrix, nan=-1)
+
+  df['positive'] = (df['image_index'] == df['gt_image_index']).astype(int)
+  gt_matrix = df.pivot_table(values='positive',
+                             index='image_index',
+                             columns='text_index').values
+
+  # If inference examples do not share the same pool, there will be missing
+  # values in the gt_matrix. In gt_matrix, 1 means the image-text pair is a
+  # matched pair. Oppositely, 0 means the pair is not matched. Missing values
+  # must be negatives. Thus, we replace the missing values with 0s to ignore them
+  # when counting scores.
+  gt_matrix = np.nan_to_num(gt_matrix, nan=0)
+
+  def rank(x, axis=-1):
+   return np.argsort(np.argsort(x, axis=axis), axis=axis)
+
+  m, n = score_matrix.shape
+  
+  # Reverses ranking indices: -n and -m and * -1.
+  i2t_rank = (rank(score_matrix, axis=1) - n) * -1
+  t2i_rank = (rank(score_matrix, axis=0) - m) * -1
+  
+  recall_dict = collections.OrderedDict()
+  # image-to-text retrieval.
+  for k in topks:
+    rank_at_gt = (i2t_rank * gt_matrix)
+    match = ((rank_at_gt <= k) & (rank_at_gt > 0)).astype(int)
+    match = np.sum(match, axis=1).astype(float)
+    match = np.clip(match, 0, 1)
+
+    num_valid_gt = np.clip(np.sum(gt_matrix, axis=1), 0, 1)
+    recall = np.divide(np.sum(match), np.sum(num_valid_gt), out=np.zeros(1))
+    recall_dict[f'i2t @ {k:>2}'] = f'{np.mean(recall):.4f}'
+  
+  # text-to-image retrieval.
+  for k in topks:
+    rank_at_gt = (t2i_rank * gt_matrix)
+    match = (rank_at_gt <= k) & (rank_at_gt > 0)
+    match = np.sum(match, axis=0).astype(float)
+    match = np.clip(match, 0, 1)
+
+    num_valid_gt = np.clip(np.sum(gt_matrix, axis=0), 0, 1)
+    recall = np.divide(np.sum(match), np.sum(num_valid_gt), out=np.zeros(1))
+    recall_dict[f't2i @ {k:>2}'] = f'{np.mean(recall):.4f}'
+
+  return recall_dict
+
+
+def _write_results(task, model, data_config, output_dir):
+  """Makes predictions and writes to output file.
+
+  There are two output files. 
+
+  1. results.csv: prediction results that contains matching scores of image-text pairs.
+  2. recall.json: recall numbers of this prediction.
+
+  """
+
+  results = classification.predict(task, data_config, model)
+
+  result_path = os.path.join(output_dir, 'results.csv')
+  with tf.io.gfile.GFile(result_path, 'w') as f:
+    # Converts list of RawResult to a dataframe.
+    results = list(map(lambda x: dict(x._asdict()), results))
+    df = pd.DataFrame(results)
+    df['output'] = df['output'].clip(upper=1.0, lower=0.0)
+    df.to_csv(f, index=False, float_format='%.8f')
+
+  recall_dict = get_recall_at_k_from_dataframe(df)
+  result_path = os.path.join(output_dir, 'recall.json')
+  with tf.io.gfile.GFile(result_path, 'w') as f:
+    json.dump(recall_dict, f, indent=4)
+
+  pp = pprint.PrettyPrinter()
+  logging.info(f'Results: {pp.pformat(recall_dict)}')
+
+
+def write_results(task, input_meta_data, flags_obj):
+
+  params = task.task_config.train_data
+  vocab_filename = params.vocab_filename
+  relative_pos_max_distance = params.relative_pos_max_distance
+  relative_att_num_core_layers = params.relative_att_num_core_layers
+  text_special_token_field_dict = params.text_special_token_field_dict
+
+  predict_split = flags_obj.predict_split
+  predict_global_batch_size = flags_obj.predict_global_batch_size
+  test_output_dir = flags_obj.test_output_dir
+
+  def get_retrieval_data_config():
+
+    input_path = input_meta_data.get(f'{predict_split}_input_path', None)
+    num_examples = input_meta_data.get(f'{predict_split}_num_examples', None)
+    seq_length = input_meta_data['max_seq_length']
+
+    if input_path is None:
+      # Enumerates all combination of examples from image and text records.
+      image_input_path = input_meta_data[f'{predict_split}_image_input_path']
+      text_input_path = input_meta_data[f'{predict_split}_text_input_path']
+      num_image_examples = input_meta_data[f'{predict_split}_num_image_examples']
+      num_text_examples = input_meta_data[f'{predict_split}_num_text_examples']
+  
+      logging.info(f'Predicting {num_image_examples} images from {image_input_path}')
+      logging.info(f'Predicting {num_text_examples} texts from {text_input_path}')
+      logging.info(f'Predicting {num_text_examples * num_image_examples} in total.')
+  
+      data_config = retrieval_dataloader.MmtRetrievalDataConfig(
+          global_batch_size=predict_global_batch_size,
+          vocab_filename=vocab_filename,
+          text_special_token_field_dict=text_special_token_field_dict,
+          is_training=False,
+          image_input_path=image_input_path,
+          text_input_path=text_input_path,
+          num_image_examples=num_image_examples,
+          num_text_examples=num_text_examples,
+          max_seq_len=seq_length,
+          drop_remainder=False,
+          include_image_text_index=True,
+          relative_pos_max_distance=relative_pos_max_distance,
+          relative_att_num_core_layers=relative_att_num_core_layers)
+    else:
+      # Image-text records.
+      logging.info(f'Predicting {num_examples} examples from {input_path}.')
+      data_config = retrieval_dataloader.MmtRetrievalDataConfig(
+          global_batch_size=predict_global_batch_size,
+          vocab_filename=vocab_filename,
+          text_special_token_field_dict=text_special_token_field_dict,
+          is_training=False,
+          input_path=input_path,
+          num_examples=num_examples,
+          max_seq_len=seq_length,
+          drop_remainder=False,
+          include_image_text_index=True,
+          relative_pos_max_distance=relative_pos_max_distance,
+          relative_att_num_core_layers=relative_att_num_core_layers)
+
+    return data_config
+
+  data_config = get_retrieval_data_config()
+
+  tf.io.gfile.makedirs(test_output_dir)
+  
+  ckpt_file = flags_obj.init_checkpoint
+  if not ckpt_file:
+    raise ValueError('No checkpoint assigned for prediction mode.')
+
+  model = task.build_model()
+  logging.info(f'Restoring checkpoint from {ckpt_file}.')
+  checkpoint = tf.train.Checkpoint(model=model)
+  status = checkpoint.read(ckpt_file).expect_partial()
+  status.expect_partial().assert_existing_objects_matched()
+  logging.info(f'Finished loading pretrained checkpoint from {ckpt_file}.')
+
+  _write_results(task, model, data_config, test_output_dir)


### PR DESCRIPTION
1. `predict.py` is the main file for prediction.
2. `prediction_helper.py` contains the functions that (1) gather the predictions from model output (2) write predictions into a file and (3) calculate recall@k.
3. `data/retrieval_dataloader.py` is dataloader for prediction. There are two mode. One is loading examples from pre-built image-text pairwise data. The other is loading image and text separately and creating pairs on the fly.